### PR TITLE
Adds Proguard deobfuscation support.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ repositories {
 }
 
 dependencies {
+  compile 'args4j:args4j:2.33'
   compile 'com.jakewharton.android.repackaged:libcore-dex:2'
   compile 'com.jakewharton.android.repackaged:dalvik-dx:1'
   compile 'org.jetbrains.kotlin:kotlin-stdlib:1.0.0'

--- a/src/main/kotlin/com/jakewharton/dex/MethodName.kt
+++ b/src/main/kotlin/com/jakewharton/dex/MethodName.kt
@@ -1,0 +1,26 @@
+package com.jakewharton.dex
+
+import java.util.*
+
+/** Data class for outputting and comparing method outputs. */
+data class MethodName(
+        val name: String, val className: TypeName, val returnType: TypeName,
+        val params: Array<TypeName>) {
+
+  override fun equals(other : Any?) : Boolean = when(other) {
+    is MethodName -> toString().equals(other.toString())
+    else -> false
+  }
+
+  override fun hashCode() = toString().hashCode()
+
+  override fun toString() : String {
+    val paramString = params.map { it }.joinToString(", ")
+    val prefix = "$className $name($paramString)"
+    return when {
+      returnType.primitive && returnType.name == "void" -> prefix
+      else -> "$prefix → $returnType"
+    }
+  }
+
+}

--- a/src/main/kotlin/com/jakewharton/dex/ProguardNameMapper.kt
+++ b/src/main/kotlin/com/jakewharton/dex/ProguardNameMapper.kt
@@ -1,0 +1,106 @@
+package com.jakewharton.dex
+
+import java.io.File
+import java.util.*
+
+/** Maps proguard-obfuscated symbol names back to their original name. */
+class ProguardNameMapper(mappingFile: String) : (MethodName) -> MethodName {
+  data class ClassMapping(
+          val original: String, val obfuscated: String,
+          val methods: MutableList<MethodMapping> = ArrayList())
+  data class MethodMapping(
+      val original: String, val obfuscated: String, val returnType: String,
+      val params: List<String>)
+
+  // Matches class renames in Proguard mappings.
+  val classRegex = Regex("""^(\S+) -> (\S+):$""")
+  // Matches nested method renames in Proguard mappings.
+  val methodRegex = Regex("""^    (\d+:\d+:)?(\S+) (\S+)\((\S*)\)(:\d+)? -> (\S+)$""")
+
+  val typeMappings : Map<String, String>
+  val reverseTypeMappings : Map<String, String>
+  val methods : Map<MethodName, MethodName>
+
+  init {
+    val mappingList = File(mappingFile).useLines {
+      it.fold<String, MutableList<ClassMapping>>(
+          ArrayList<ClassMapping>(), { mappings, line -> mappings + line })
+    }
+
+    typeMappings = mappingList.associateBy({ it.original }, { it.obfuscated })
+    methods = mappingList.flatMap { cls ->
+      cls.methods.map {
+        val originalParams = it.params.map { parseProguardType(it) }
+        val obfuscatedParams = it.params.map { parseAndMapProguardType(it) }
+        val originalReturnType = parseProguardType(it.returnType)
+        val obfuscatedReturnType = parseAndMapProguardType(it.returnType)
+        Pair(
+            MethodName(
+                it.obfuscated, parseProguardType(cls.obfuscated, stripPackage = false),
+                obfuscatedReturnType, obfuscatedParams.toTypedArray()),
+            MethodName(
+                it.original, parseProguardType(cls.original, stripPackage=false), originalReturnType,
+                originalParams.toTypedArray())
+        )
+      }
+
+    }.associateBy({ it.first }, { it.second })
+    reverseTypeMappings = typeMappings.entries.associateBy({ it.value }, { it.key })
+  }
+
+  fun <T> MatchResult?.valuesOnMatch(fn : (List<String>) -> T) : T?
+       = if (this != null) fn(this.groupValues) else null
+
+  operator fun MutableList<ClassMapping>.plus(mapping: ClassMapping) : MutableList<ClassMapping> {
+    add(mapping)
+    return this
+  }
+
+  operator fun MutableList<ClassMapping>.plus(mapping: MethodMapping)
+          : MutableList<ClassMapping> {
+    last().methods.add(mapping)
+    return this
+  }
+
+  operator fun MutableList<ClassMapping>.plus(line: String) : MutableList<ClassMapping> =
+      classRegex.matchEntire(line).valuesOnMatch {
+          this + ClassMapping(it[1], it[2])
+      } ?: methodRegex.matchEntire(line).valuesOnMatch {
+          this + MethodMapping(it[3], it[6], it[2], it[4].split(','))
+      } ?: this
+
+  private fun String.stripPackage() : String = this.split(".").last()
+
+  private fun parseProguardType(type: String, stripPackage: Boolean=true) : TypeName = when {
+    type.endsWith("[]") -> parseProguardType(type.substring(0, type.length - 2)).toArrayType()
+    else -> TypeName(
+        if (stripPackage) type.stripPackage() else type,
+        primitive = type in arrayOf(
+            "byte", "char", "double", "float", "int", "long", "short", "void", "boolean"))
+  }
+
+  private fun parseAndMapProguardType(type: String) : TypeName =
+      mapType(parseProguardType(typeMappings.get(type) ?: type))
+
+  private fun mapType(type: TypeName) = when {
+    type.primitive -> type
+    else -> type.copy(name=typeMappings.get(type.name) ?: type.name)
+  }
+
+  private fun reverseMapType(type: TypeName) = when {
+    type.primitive -> type
+    else -> type.copy(name=reverseTypeMappings.get(type.name) ?: type.name)
+  }
+
+    override fun invoke(name: MethodName) : MethodName {
+      val mapped = methods.get(name)
+      return when (mapped) {
+        null -> name.copy(
+            className = reverseMapType(name.className),
+            returnType = reverseMapType(name.returnType),
+            params = name.params.map { reverseMapType(it) }.toTypedArray())
+        else -> mapped
+      }
+    }
+
+}

--- a/src/main/kotlin/com/jakewharton/dex/TypeName.kt
+++ b/src/main/kotlin/com/jakewharton/dex/TypeName.kt
@@ -1,0 +1,33 @@
+package com.jakewharton.dex
+
+/** Simple representation of a type name. Marks primitives to prevent deobfuscation attempts. */
+data class TypeName(val name: String, val primitive: Boolean = false, val array: Boolean = false) {
+
+  companion object {
+    fun parse(type: String, stripPackage: Boolean = false) : TypeName = when {
+      type.startsWith("[") -> parse(type.substring(1), stripPackage).toArrayType()
+      type.startsWith("L") -> {
+        val name = type.substring(1, type.length - 1)
+        if (stripPackage) TypeName(name.split('/').last())
+        else TypeName(name.replace('/', '.'))
+      }
+      else -> when(type) {
+        "B" -> TypeName("byte", primitive = true)
+        "C" -> TypeName("char", primitive = true)
+        "D" -> TypeName("double", primitive = true)
+        "F" -> TypeName("float", primitive = true)
+        "I" -> TypeName("int", primitive = true)
+        "J" -> TypeName("long", primitive = true)
+        "S" -> TypeName("short", primitive = true)
+        "V" -> TypeName("void", primitive = true)
+        "Z" -> TypeName("boolean", primitive = true)
+        else -> throw IllegalArgumentException("Unknown type $type")
+      }
+    }
+  }
+
+  override fun toString() : String = "$name" + if (array) "[]" else ""
+
+  fun toArrayType() = TypeName(name, primitive=primitive, array=true)
+}
+

--- a/src/test/kotlin/com/jakewharton/dex/DexMethodsTest.kt
+++ b/src/test/kotlin/com/jakewharton/dex/DexMethodsTest.kt
@@ -27,6 +27,29 @@ class DexMethodsTest {
         "java.lang.Object <init>()")
   }
 
+  @Test fun typesDeobfuscated() {
+    val types = File(Resources.getResource("types.dex").file);
+    val bytes = types.readBytes()
+    val methods = DexMethods.list(
+        listOf(bytes), false, ProguardNameMapper(Resources.getResource("obfuscation.map").file))
+    assertThat(methods).containsExactly(
+        "Typos <init>()",
+        "Typos stringTest(String)",
+        "Typos stringArrayTest(String[])",
+        "Typos booleanTest(boolean)",
+        "Typos byteTest(byte)",
+        "Typos charTest(char)",
+        "Typos doubleTest(double)",
+        "Typos floatTest(float)",
+        "Typos intTest(int)",
+        "Typos longTest(long)",
+        "Typos shortTest(short)",
+        "Typos runnableReturned() → Runnable",
+        "Typos stringReturned() → String",
+        "Typos returnsBoolean() → boolean",  // Intentionally not obfuscated.
+        "java.lang.Object <init>()")
+  }
+
   @Test fun paramsJoined() {
     val params = File(Resources.getResource("params_joined.dex").file)
     val methods = DexMethods.list(params)

--- a/src/test/resources/obfuscation.map
+++ b/src/test/resources/obfuscation.map
@@ -1,0 +1,13 @@
+Typos -> Types:
+    void booleanTest(boolean) -> test
+    void byteTest(byte) -> test
+    void charTest(char) -> test
+    void doubleTest(double) -> test
+    void floatTest(float) -> test
+    void intTest(int) -> test
+    void longTest(long) -> test
+    void shortTest(short) -> test
+    void stringTest(String) -> test
+    void stringArrayTest(String[]) -> test
+    Runnable runnableReturned() -> returnsRunnable
+    String stringReturned() -> returnsString


### PR DESCRIPTION
This patch has been really useful to me so far in analyzing methods on some of our obfuscated YouTube release builds. It does restructure things a bit, such as making objects for the names and using Args4J for command line processing, so interested to hear if you'd like to merge something like this in. I know the alternative would be to use unobfuscated Proguard builds, but this allows users to analyze exact release builds, which I think adds some value to the app.

Also, very much enjoying getting to play with some Kotlin, so please let me know if my usage of the language is wonky anywhere so I can get to know the idioms better. Thanks!
