### PR TITLE
De-duplicate members, methods, and fields

### DIFF
--- a/src/main/kotlin/com/jakewharton/dex/DexParser.kt
+++ b/src/main/kotlin/com/jakewharton/dex/DexParser.kt
@@ -2,6 +2,7 @@ package com.jakewharton.dex
 
 import java.io.File
 import java.nio.file.Path
+import java.util.TreeSet
 
 /** Parser for method and field references inside of a dex file. */
 class DexParser private constructor(
@@ -14,12 +15,12 @@ class DexParser private constructor(
   @JvmOverloads
   fun withLegacyDx(legacyDx: Boolean = true) = DexParser(bytes, legacyDx)
 
-  fun list() = dexes.flatMap { dex ->
+  fun list() = dexes.flatMapTo(TreeSet()) { dex ->
     dex.methodIds().map(dex::getMethod) + dex.fieldIds().map(dex::getField)
-  }.sorted()
+  }
 
-  fun listMethods() = dexes.flatMap { dex -> dex.methodIds().map(dex::getMethod) }.sorted()
-  fun listFields() = dexes.flatMap { dex -> dex.fieldIds().map(dex::getField) }.sorted()
+  fun listMethods() = dexes.flatMapTo(TreeSet()) { dex -> dex.methodIds().map(dex::getMethod) }
+  fun listFields() = dexes.flatMapTo(TreeSet()) { dex -> dex.fieldIds().map(dex::getField) }
 
   companion object {
     /** Create a [DexParser] from of any `.dex`, `.class`, `.jar`, `.aar`, or `.apk`. */

--- a/src/main/kotlin/com/jakewharton/dex/ListCommands.kt
+++ b/src/main/kotlin/com/jakewharton/dex/ListCommands.kt
@@ -55,7 +55,9 @@ internal class MembersCommand : BaseCommand("dex-members-list") {
     if (hideSyntheticNumbers && mode == Mode.Fields) {
       println("WARN: --hide-synthetic-numbers has no effect when --fields is used.")
     }
-    list.map { it.render(hideSyntheticNumbers) }.forEach(::println)
+    list.map { it.render(hideSyntheticNumbers) }
+        .sorted() // Re-sort because rendering my subtly change ordering.
+        .forEach(::println)
   }
 }
 
@@ -64,6 +66,8 @@ internal class FieldCommand : BaseCommand("dex-field-list") {
     DexParser.fromBytes(loadInputs())
         .withLegacyDx(legacyDx)
         .listFields()
+        .map { it.render() }
+        .sorted() // Re-sort because rendering my subtly change ordering.
         .forEach(::println)
   }
 }
@@ -76,6 +80,7 @@ internal class MethodCommand : BaseCommand("dex-method-list") {
         .withLegacyDx(legacyDx)
         .listMethods()
         .map { it.render(hideSyntheticNumbers) }
+        .sorted() // Re-sort because rendering my subtly change ordering.
         .forEach(::println)
   }
 }

--- a/src/test/kotlin/com/jakewharton/dex/DexMethodsTest.kt
+++ b/src/test/kotlin/com/jakewharton/dex/DexMethodsTest.kt
@@ -28,20 +28,21 @@ class DexMethodsTest {
         .map { it.render() }
     assertThat(methods).containsExactly(
         "Types <init>()",
-        "Types test(String)",
-        "Types test(String[])",
+        "Types returnsBoolean() → boolean",
+        "Types returnsRunnable() → Runnable",
+        "Types returnsString() → String",
         "Types test(boolean)",
         "Types test(byte)",
         "Types test(char)",
         "Types test(double)",
         "Types test(float)",
         "Types test(int)",
+        "Types test(String)",
+        "Types test(String[])",
         "Types test(long)",
         "Types test(short)",
-        "Types returnsRunnable() → Runnable",
-        "Types returnsString() → String",
-        "Types returnsBoolean() → boolean",
-        "java.lang.Object <init>()")
+        "java.lang.Object <init>()"
+    ).inOrder()
   }
 
   @Test fun paramsJoined() {
@@ -53,7 +54,8 @@ class DexMethodsTest {
     assertThat(methods).containsExactly(
         "Params <init>()",
         "Params test(String, String, String, String)",
-        "java.lang.Object <init>()")
+        "java.lang.Object <init>()"
+    ).inOrder()
   }
 
   @Test fun visibilities() {
@@ -68,7 +70,8 @@ class DexMethodsTest {
         "Visibilities test2()",
         "Visibilities test3()",
         "Visibilities test4()",
-        "java.lang.Object <init>()")
+        "java.lang.Object <init>()"
+    ).inOrder()
   }
 
   @Test fun multipleDexFiles() {
@@ -86,8 +89,8 @@ class DexMethodsTest {
         "Visibilities test2()",
         "Visibilities test3()",
         "Visibilities test4()",
-        "java.lang.Object <init>()",
-        "java.lang.Object <init>()")
+        "java.lang.Object <init>()"
+    ).inOrder()
   }
 
   @Test fun apk() {
@@ -98,20 +101,21 @@ class DexMethodsTest {
         .map { it.render() }
     assertThat(methods).containsExactly(
         "Types <init>()",
-        "Types test(String)",
-        "Types test(String[])",
+        "Types returnsBoolean() → boolean",
+        "Types returnsRunnable() → Runnable",
+        "Types returnsString() → String",
         "Types test(boolean)",
         "Types test(byte)",
         "Types test(char)",
         "Types test(double)",
         "Types test(float)",
         "Types test(int)",
+        "Types test(String)",
+        "Types test(String[])",
         "Types test(long)",
         "Types test(short)",
-        "Types returnsRunnable() → Runnable",
-        "Types returnsString() → String",
-        "Types returnsBoolean() → boolean",
-        "java.lang.Object <init>()")
+        "java.lang.Object <init>()"
+    ).inOrder()
   }
 
   @Test fun apkMultipleDex() {
@@ -124,27 +128,26 @@ class DexMethodsTest {
         "Params <init>()",
         "Params test(String, String, String, String)",
         "Types <init>()",
-        "Types test(String)",
-        "Types test(String[])",
+        "Types returnsBoolean() → boolean",
+        "Types returnsRunnable() → Runnable",
+        "Types returnsString() → String",
         "Types test(boolean)",
         "Types test(byte)",
         "Types test(char)",
         "Types test(double)",
         "Types test(float)",
         "Types test(int)",
+        "Types test(String)",
+        "Types test(String[])",
         "Types test(long)",
         "Types test(short)",
-        "Types returnsRunnable() → Runnable",
-        "Types returnsString() → String",
-        "Types returnsBoolean() → boolean",
         "Visibilities <init>()",
         "Visibilities test1()",
         "Visibilities test2()",
         "Visibilities test3()",
         "Visibilities test4()",
-        "java.lang.Object <init>()",
-        "java.lang.Object <init>()",
-        "java.lang.Object <init>()")
+        "java.lang.Object <init>()"
+    ).inOrder()
   }
 
   @Test fun classFile() {
@@ -156,7 +159,8 @@ class DexMethodsTest {
     assertThat(methods).containsExactly(
         "Params <init>()",
         "Params test(String, String, String, String)",
-        "java.lang.Object <init>()")
+        "java.lang.Object <init>()"
+    ).inOrder()
   }
 
   @Test fun multipleClassFiles() {
@@ -174,7 +178,8 @@ class DexMethodsTest {
         "Visibilities test2()",
         "Visibilities test3()",
         "Visibilities test4()",
-        "java.lang.Object <init>()")
+        "java.lang.Object <init>()"
+    ).inOrder()
   }
 
   @Test fun jarFile() {
@@ -186,7 +191,8 @@ class DexMethodsTest {
     assertThat(methods).containsExactly(
         "Params <init>()",
         "Params test(String, String, String, String)",
-        "java.lang.Object <init>()")
+        "java.lang.Object <init>()"
+    ).inOrder()
   }
 
   @Test fun multipleJarFiles() {
@@ -204,7 +210,8 @@ class DexMethodsTest {
         "Visibilities test2()",
         "Visibilities test3()",
         "Visibilities test4()",
-        "java.lang.Object <init>()")
+        "java.lang.Object <init>()"
+    ).inOrder()
   }
 
   @Test fun jarMultipleClasses() {
@@ -217,25 +224,26 @@ class DexMethodsTest {
         "Params <init>()",
         "Params test(String, String, String, String)",
         "Types <init>()",
-        "Types test(String)",
-        "Types test(String[])",
+        "Types returnsBoolean() → boolean",
+        "Types returnsRunnable() → Runnable",
+        "Types returnsString() → String",
         "Types test(boolean)",
         "Types test(byte)",
         "Types test(char)",
         "Types test(double)",
         "Types test(float)",
         "Types test(int)",
+        "Types test(String)",
+        "Types test(String[])",
         "Types test(long)",
         "Types test(short)",
-        "Types returnsRunnable() → Runnable",
-        "Types returnsString() → String",
-        "Types returnsBoolean() → boolean",
         "Visibilities <init>()",
         "Visibilities test1()",
         "Visibilities test2()",
         "Visibilities test3()",
         "Visibilities test4()",
-        "java.lang.Object <init>()")
+        "java.lang.Object <init>()"
+    ).inOrder()
   }
 
   @Test fun dexBytes() {
@@ -247,7 +255,8 @@ class DexMethodsTest {
     assertThat(methods).containsExactly(
         "Params <init>()",
         "Params test(String, String, String, String)",
-        "java.lang.Object <init>()")
+        "java.lang.Object <init>()"
+    ).inOrder()
   }
 
   @Test fun apkBytes() {
@@ -258,20 +267,21 @@ class DexMethodsTest {
         .map { it.render() }
     assertThat(methods).containsExactly(
         "Types <init>()",
-        "Types test(String)",
-        "Types test(String[])",
+        "Types returnsBoolean() → boolean",
+        "Types returnsRunnable() → Runnable",
+        "Types returnsString() → String",
         "Types test(boolean)",
         "Types test(byte)",
         "Types test(char)",
         "Types test(double)",
         "Types test(float)",
         "Types test(int)",
+        "Types test(String)",
+        "Types test(String[])",
         "Types test(long)",
         "Types test(short)",
-        "Types returnsRunnable() → Runnable",
-        "Types returnsString() → String",
-        "Types returnsBoolean() → boolean",
-        "java.lang.Object <init>()")
+        "java.lang.Object <init>()"
+    ).inOrder()
   }
 
   @Test fun classBytes() {
@@ -283,7 +293,8 @@ class DexMethodsTest {
     assertThat(methods).containsExactly(
         "Params <init>()",
         "Params test(String, String, String, String)",
-        "java.lang.Object <init>()")
+        "java.lang.Object <init>()"
+    ).inOrder()
   }
 
   @Test fun jarBytes() {
@@ -295,7 +306,8 @@ class DexMethodsTest {
     assertThat(methods).containsExactly(
         "Params <init>()",
         "Params test(String, String, String, String)",
-        "java.lang.Object <init>()")
+        "java.lang.Object <init>()"
+    ).inOrder()
   }
 
   @Test fun aarExtractsJars() {
@@ -308,25 +320,26 @@ class DexMethodsTest {
         "Params <init>()",
         "Params test(String, String, String, String)",
         "Types <init>()",
-        "Types test(String)",
-        "Types test(String[])",
+        "Types returnsBoolean() → boolean",
+        "Types returnsRunnable() → Runnable",
+        "Types returnsString() → String",
         "Types test(boolean)",
         "Types test(byte)",
         "Types test(char)",
         "Types test(double)",
         "Types test(float)",
         "Types test(int)",
+        "Types test(String)",
+        "Types test(String[])",
         "Types test(long)",
         "Types test(short)",
-        "Types returnsRunnable() → Runnable",
-        "Types returnsString() → String",
-        "Types returnsBoolean() → boolean",
         "Visibilities <init>()",
         "Visibilities test1()",
         "Visibilities test2()",
         "Visibilities test3()",
         "Visibilities test4()",
-        "java.lang.Object <init>()")
+        "java.lang.Object <init>()"
+    ).inOrder()
   }
 
   @Test fun synthetics() {
@@ -346,7 +359,7 @@ class DexMethodsTest {
         "Synthetics\$Inner <init>(Synthetics)",
         "java.io.PrintStream println(int)",
         "java.lang.Object <init>()"
-    )
+    ).inOrder()
   }
 
   @Test fun syntheticsWithoutNumbers() {
@@ -359,14 +372,14 @@ class DexMethodsTest {
     assertThat(methods).containsExactly(
         "Synthetics <init>()",
         "Synthetics access(Synthetics) → int",
-        "Synthetics access(Synthetics) → int",
-        "Synthetics access(Synthetics) → int",
-        "Synthetics access(Synthetics) → int",
-        "Synthetics access(Synthetics) → int",
         "Synthetics access(Synthetics, int) → int",
+        "Synthetics access(Synthetics) → int",
+        "Synthetics access(Synthetics) → int",
+        "Synthetics access(Synthetics) → int",
+        "Synthetics access(Synthetics) → int",
         "Synthetics\$Inner <init>(Synthetics)",
         "java.io.PrintStream println(int)",
         "java.lang.Object <init>()"
-    )
+    ).inOrder()
   }
 }

--- a/src/test/kotlin/com/jakewharton/dex/DexParserTest.kt
+++ b/src/test/kotlin/com/jakewharton/dex/DexParserTest.kt
@@ -28,19 +28,19 @@ class DexParserTest {
         .map { it.toString() }
     assertThat(methods).containsExactly(
         "Types <init>()",
-        "Types test(String)",
-        "Types test(String[])",
+        "Types returnsBoolean() → boolean",
+        "Types returnsRunnable() → Runnable",
+        "Types returnsString() → String",
         "Types test(boolean)",
         "Types test(byte)",
         "Types test(char)",
         "Types test(double)",
         "Types test(float)",
         "Types test(int)",
+        "Types test(String)",
+        "Types test(String[])",
         "Types test(long)",
         "Types test(short)",
-        "Types returnsRunnable() → Runnable",
-        "Types returnsString() → String",
-        "Types returnsBoolean() → boolean",
         "Types valueBoolean: boolean",
         "Types valueByte: byte",
         "Types valueChar: char",
@@ -51,6 +51,7 @@ class DexParserTest {
         "Types valueShort: short",
         "Types valueString: String",
         "Types valueStringArray: String[]",
-        "java.lang.Object <init>()")
+        "java.lang.Object <init>()"
+    ).inOrder()
   }
 }


### PR DESCRIPTION
Re-sort strings after rendering since we render parameters and return types in a way that sorts differently.