### PR TITLE
Remove more synthetic numbers

### DIFF
--- a/src/test/kotlin/com/jakewharton/dex/DexFieldTest.kt
+++ b/src/test/kotlin/com/jakewharton/dex/DexFieldTest.kt
@@ -5,8 +5,24 @@ import org.junit.Test
 
 class DexFieldTest {
   @Test fun string() {
-    val method = DexField("com.example.Foo", "bar", "com.example.Bar")
-    assertThat(method.toString()).isEqualTo("com.example.Foo bar: Bar")
+    val field = DexField("com.example.Foo", "bar", "com.example.Bar")
+    assertThat(field.toString()).isEqualTo(field.render())
+  }
+
+  @Test fun render() {
+    val field = DexField("com.example.Foo", "bar", "com.example.Bar")
+    assertThat(field.render()).isEqualTo("com.example.Foo bar: Bar")
+  }
+
+  @Test fun renderKotlinLambdaClassName() {
+    val field = DexField("com.example.Foo$\$Lambda$26", "bar", "com.example.Bar")
+    assertThat(field.render()).isEqualTo("com.example.Foo$\$Lambda$26 bar: Bar")
+  }
+
+  @Test fun renderKotlinLambdaClassNameHidingSynthetics() {
+    val field = DexField("com.example.Foo$\$Lambda$26", "bar", "com.example.Bar")
+    assertThat(field.render(hideSyntheticNumbers = true))
+        .isEqualTo("com.example.Foo$\$Lambda bar: Bar")
   }
 
   @Test fun compareToSame() {

--- a/src/test/kotlin/com/jakewharton/dex/DexMethodTest.kt
+++ b/src/test/kotlin/com/jakewharton/dex/DexMethodTest.kt
@@ -4,6 +4,11 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 class DexMethodTest {
+  @Test fun toStringCallsRender() {
+    val method = DexMethod("com.example.Foo", "bar", emptyList(), "com.example.Bar")
+    assertThat(method.toString()).isEqualTo(method.render())
+  }
+
   @Test fun render() {
     val method = DexMethod("com.example.Foo", "bar", emptyList(), "com.example.Bar")
     assertThat(method.render()).isEqualTo("com.example.Foo bar() → Bar")
@@ -27,6 +32,32 @@ class DexMethodTest {
     val synthetic = DexMethod("com.example.Foo", "access$000", emptyList(), "com.example.Bar")
     assertThat(synthetic.render(hideSyntheticNumbers = true))
         .isEqualTo("com.example.Foo access() → Bar")
+  }
+
+  @Test fun renderKotlinLambdaFunctionName() {
+    val synthetic = DexMethod("com.example.Foo", "lambda\$refreshSessionToken$14\$MainActivity", emptyList(), "com.example.Bar")
+    assertThat(synthetic.render()).isEqualTo("com.example.Foo lambda\$refreshSessionToken$14\$MainActivity() → Bar")
+  }
+
+  @Test fun renderKotlinLambdaFunctionNameHidingSynthetics() {
+    val method = DexMethod("com.example.Foo", "bar", emptyList(), "com.example.Bar")
+    assertThat(method.render(hideSyntheticNumbers = true))
+        .isEqualTo("com.example.Foo bar() → Bar")
+
+    val synthetic = DexMethod("com.example.Foo", "lambda\$refreshSessionToken$14\$MainActivity", emptyList(), "com.example.Bar")
+    assertThat(synthetic.render(hideSyntheticNumbers = true))
+        .isEqualTo("com.example.Foo lambda\$refreshSessionToken\$MainActivity() → Bar")
+  }
+
+  @Test fun renderKotlinLambdaClassName() {
+    val synthetic = DexMethod("com.example.Foo$\$Lambda$26", "bar", emptyList(), "com.example.Bar")
+    assertThat(synthetic.render()).isEqualTo("com.example.Foo$\$Lambda$26 bar() → Bar")
+  }
+
+  @Test fun renderKotlinLambdaClassNameHidingSynthetics() {
+    val synthetic = DexMethod("com.example.Foo$\$Lambda$26", "bar", emptyList(), "com.example.Bar")
+    assertThat(synthetic.render(hideSyntheticNumbers = true))
+        .isEqualTo("com.example.Foo$\$Lambda bar() → Bar")
   }
 
   @Test fun compareToSame() {


### PR DESCRIPTION
This removes numbers associated with Kotlin lambdas which are used in the declaring class of methods and fields and also the method name of, well, methods.

Update commands now that number hiding works for both methods and fields.

Closes #49 