### PR TITLE
Update R8 and remove extra repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,15 +27,14 @@ repositories {
   mavenCentral()
   google()
   jcenter()
-
-  // TODO remove https://youtrack.jetbrains.com/issue/KT-27991
-  maven { url "https://kotlin.bintray.com/kotlinx" }
 }
 
 dependencies {
   implementation 'com.github.ajalt:clikt:1.5.0'
   implementation 'com.jakewharton.android.repackaged:dalvik-dx:9.0.0_r3'
-  implementation 'com.android.tools:r8:1.3.52'
+  implementation 'com.android.tools:r8:1.4.93'
+  // TODO remove explicit metadata-jvm dependency on next major r8 update
+  implementation 'org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.0.5'
   implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.21'
   testImplementation 'junit:junit:4.12'
   testImplementation 'com.google.guava:guava:26.0-jre'


### PR DESCRIPTION
The extra kotlinx repository was required to be added on the user side, this PR removes that dependency.

https://youtrack.jetbrains.com/issue/KT-27991 is fixed., but sadly R8 didn't catch up yet.
I changed it to the most compatible version 0.0.5. It's published in mavenCentral, it's closest to what R8 has, dex-member-list's Kotlin (1.3.21) is closest to its Kotlin version and it has no breaking changes like 0.0.6 does.

| R8 | metadata-jvm | kotlin | repo |
|-|-|-|-|
| 1.3.52 | 0.0.3 | 1.2.50 | kotlin.bintray |
| 1.4.93 | 0.0.4 | 1.2.50 | kotlin.bintray |
| - | 0.0.5 | 1.3.11 | mavenCentral |
| - | 0.0.6 | 1.3.31 | mavenCentral |

Based on
 * https://bintray.com/kotlin/kotlinx/kotlinx.metadata#release
 * https://mvnrepository.com/artifact/com.android.tools/r8/1.4.93
 * https://search.maven.org/artifact/org.jetbrains.kotlinx/kotlinx-metadata-jvm/0.0.5/jar